### PR TITLE
Don't set message and logger to null

### DIFF
--- a/src/main/java/ru/vyarus/dropwizard/guice/module/installer/util/Reporter.java
+++ b/src/main/java/ru/vyarus/dropwizard/guice/module/installer/util/Reporter.java
@@ -21,13 +21,14 @@ public class Reporter {
     // marker to be able switch off reports easily
     private static final Marker MARKER = MarkerFactory.getMarker("installer reporter");
 
-    private Logger logger;
-    private StringBuilder message = new StringBuilder();
+    private final Logger logger;
+    private StringBuilder message;
     private int counter;
     private boolean wasEmptyLine;
 
     public Reporter(final Class<? extends FeatureInstaller> type, final String title) {
         this.logger = LoggerFactory.getLogger(type);
+        this.message = new StringBuilder();
         message.append(title).append(NEWLINE);
         emptyLine();
     }
@@ -87,8 +88,6 @@ public class Reporter {
         if (counter > 0) {
             logger.info(MARKER, message.toString());
         }
-        // free memory
-        message = null;
-        logger = null;
+        message = new StringBuilder();
     }
 }


### PR DESCRIPTION
If message and logger are set to null, when JRebel (or other class reloading tool) reloads jersey resources, the Reporter is run again and there is a NullPointerException due to `message` (and `logger`) being null after the last time `report()` was called.

This patch removes the code that sets `logger` to null and assigns a new instance of StringBuilder to `message` instead of setting it to null.

Fixes #29 