### PR TITLE
Allow Loggers to be used with TestCommand

### DIFF
--- a/src/main/java/ru/vyarus/dropwizard/guice/test/TestCommand.java
+++ b/src/main/java/ru/vyarus/dropwizard/guice/test/TestCommand.java
@@ -22,6 +22,7 @@ public class TestCommand<C extends Configuration> extends EnvironmentCommand<C> 
 
     public TestCommand(final Application<C> application) {
         super(application, "guicey-test", "Specific command to run guice context without jetty server");
+        cleanupAsynchronously();
         configurationClass = application.getConfigurationClass();
     }
 
@@ -41,6 +42,7 @@ public class TestCommand<C extends Configuration> extends EnvironmentCommand<C> 
             throw new IllegalStateException("Failed to stop managed objects container", e);
         }
         container.destroy();
+        cleanup();
     }
 
     @Override


### PR DESCRIPTION
Using `slf4j.Logger` currently doesn't work when using `TestCommand`, because `TestCommand` only stars the environment lifecycle and exists, and the  `ConfiguredCommand` superclass cleans up the loggers after the `run()` method completes:

https://github.com/dropwizard/dropwizard/blob/master/dropwizard-core/src/main/java/io/dropwizard/cli/ConfiguredCommand.java#L88-L99

This can be avoided by running `cleanupAsynchronously()` in `TestCommand`