### PR TITLE
Documentation Cleanup: landing page, getting-started, and guide/bundles

### DIFF
--- a/src/doc/docs/getting-started.md
+++ b/src/doc/docs/getting-started.md
@@ -229,7 +229,7 @@ public class SampleBootstrap implements Managed {
 }
 ```
 
-It will be automatically discovered and installed by the application. Guicey always reports installed extensions
+The managed class will be automatically discovered and installed by Guicey. Guicey always reports installed extensions
 when they are not reported by dropwizard itself. In the start-up logs of the application, you can see:
 
 ```
@@ -299,13 +299,13 @@ bootstrap.addBundle(GuiceBundle.builder()
 
 Multiple modules could be registered at once:
 ```java
-.modules(new SampleModule(), new Some3rdPatyModule())
+.modules(new SampleModule(), new Some3rdPartyModule())
 ```
 
 !!! note
     The above registration occurs in dropwizard initialization phase, when neither `Configuration`
-    nor `Environment` objects are available. If you need access to them in a module then either
-    register module in [guicey bundle's](guide/bundles.md#guicey-bundles) run method or use [marker interfaces](guide/guice/module-autowiring.md)
+    nor `Environment` objects are available. If you need either of them in a module, you may register a module in 
+    [guicey bundle's](guide/bundles.md#guicey-bundles) `run` method or use [marker interfaces](guide/guice/module-autowiring.md).
         
 ## Manual mode
 
@@ -323,11 +323,11 @@ bootstrap.addBundle(GuiceBundle.builder()
                 .build());
 ```
 
-The only difference is the absence of `.enableAutoConfig(...)` and the explicit declaration of desired all extensions.
+The only difference is the absence of `.enableAutoConfig(...)` and the explicit declaration of desired extensions.
 
 !!! tip
     Explicit extension declaration could be used together with `enableAutoConfig` (classpath scan). For example,
-    a classpath scan may only scan for extensions in your application's package and subpackages, while extensions from outside 
+    a classpath scan may only scan for extensions in your application's package and subpackages, while extensions outside of
     those packages may be specified separately. This avoids large class path scans and improves the startup time of your 
     application.
 
@@ -361,8 +361,8 @@ or manual declaration is only that guicey will not declare default bindings for 
 (by default, guicey creates untargetted bindings for all extensions: `bind(Extension.class)`).
 
 !!! tip
-    One extension may be found by classpath scan and declared manually in binding,
-    but it would still be considered as single registration (with existing binding).
+    An extension may be found three ways: by classpath scan, explicit extension declaration on the GuiceBundle, and by 
+    declaring a binding in a guice module. Even if all three were used, the extension would only be registered once.
 
 ## Recognized Extensions
 

--- a/src/doc/docs/getting-started.md
+++ b/src/doc/docs/getting-started.md
@@ -2,7 +2,7 @@
 
 !!! note ""
     Getting started guide briefly shows the most commonly used features.
-    Advanced description of guicey concepts may be found in [the concepts section](concepts.md).    
+    Advanced descriptions of guicey concepts may be found in [the concepts section](concepts.md).    
 
 ## Installation
 
@@ -120,10 +120,10 @@ public class SampleApplication extends Application<Configuration> {
 
 !!! tip
     Bundle builder contains shortcuts for all available features, so required function 
-    may be found only by looking at available methods (and reading javadoc).
+    may be found only by looking at available methods (and reading the javadoc).
 
 [Auto configuration](guide/scan.md) (activated with `enableAutoConfig`) means that guicey will search for extensions in 
-application package and subpackages. Extension classes are detected by "feature markers": for example, 
+the application package and subpackages. Extension classes are detected by "feature markers": for example, 
 resources has `@Path` annotation, tasks extends `Task` etc.
 
 
@@ -133,18 +133,18 @@ resources has `@Path` annotation, tasks extends `Task` etc.
      .enableAutoConfig("com.mycompany.foo", "com.mycompany.bar")
     ```
 
-Application could be launched by simply running main class (assume you will use IDE run command):
+The application could be launched by running main class (assumes you will use an IDE run command):
 
 ```bash
 SampleApplication server
 ```
 
 !!! note
-    config.yml is not passed as parameter because we don't need additional configuration now
+    a config.yml is not passed as a parameter because we don't need additional configuration yet
 
-### Add resource
+### Adding a Resource
 
-Creating custom rest resource:
+Create a custom rest resource class:
 
 ```java
 @Path("/sample")
@@ -159,7 +159,7 @@ public class SampleResource {
 }
 ```
 
-Now, when you run application, you can see that resource was installed automatically:
+After creating your resource, when you run the application the resource was installed automatically:
 
 ```
 INFO  [2017-02-05 11:23:31,188] io.dropwizard.jersey.DropwizardResourceConfig: The following paths were found for the configured resources:
@@ -176,8 +176,9 @@ Call `http://localhost:8080/sample/` to make sure it works.
         rootPath: '/rest/*'
     ```
 
-Resource is a guice bean, so you can use guice injection inside it. To access request specific
-objects like request, response, jersey `javax.ws.rs.core.UriInfo` etc. use `Provider`:
+Resource is a guice bean, so you can use guice injection inside it. To access request scoped objects like `javax.servlet.http.
+HttpServletRequest`, `javax.servlet.http.HttpServletResponse`, `javax.ws.rs.core.UriInfo`, `org.glassfish.jersey.server.
+ContainerRequest`, etc, you must wrap the desired objects in a `Provider`:
 
 ```java
 @Path("/sample")
@@ -196,7 +197,7 @@ public class SampleResource {
 }
 ```
 
-Now resource will return caller IP.
+The example resource now obtains the caller's remote ip address and returns it in the response body.
 
 !!! warning
     Providers must be used [instead of `@Context` field injections](installers/resource.md#context-usage) 
@@ -205,11 +206,11 @@ Now resource will return caller IP.
 !!! note
     By default, resources are **forced to be singletons** (when no scope annotation defined). 
 
-### Add managed
+### Adding a Managed Object
 
 [Dropwizard managed objects](https://www.dropwizard.io/en/release-2.0.x/manual/core.html#managed-objects) are extremely useful for managing resources.
 
-Create simple managed implementation:
+Create a simple managed implementation:
 
 ```java
 @Singleton
@@ -228,8 +229,8 @@ public class SampleBootstrap implements Managed {
 }
 ```
 
-It will be automatically discovered and installed. Guicey always reports installed extensions
-(when they are not reported by dropwizard itself). So you can see in startup logs now:
+It will be automatically discovered and installed by the application. Guicey always reports installed extensions
+when they are not reported by dropwizard itself. In the start-up logs of the application, you can see:
 
 ```
 INFO  [2017-02-05 11:59:30,750] ru.vyarus.dropwizard.guice.module.installer.feature.ManagedInstaller: managed =
@@ -237,7 +238,7 @@ INFO  [2017-02-05 11:59:30,750] ru.vyarus.dropwizard.guice.module.installer.feat
     (ru.vyarus.dropwizard.guice.examples.service.SampleBootstrap)
 ```
 
-### Add filter
+### Adding A Filter
 
 !!! note
     Guice [ServletModule](guide/guice/servletmodule.md) may be used for servlets and filters definitions, but most of 
@@ -245,7 +246,7 @@ INFO  [2017-02-05 11:59:30,750] ru.vyarus.dropwizard.guice.module.installer.feat
     [@WebServlet](installers/servlet.md), [@WebListener](installers/listener.md)). 
     Moreover, guice servlet module is not able to register async [filters](installers/filter.md#async) and [servlets](installers/servlet.md#async).
 
-Add sample filter around rest methods:
+Add a sample filter around rest methods:
 
 ```java
 @WebFilter(urlPatterns = "/*")
@@ -272,10 +273,10 @@ public class CustomHeaderFilter implements Filter {
 }
 ```
 
-Filter will pass through only requests with `user=me` request parameter. It is used just to show
-how to register custom filters with annotations (implementation itself is not useful).
+The filter will only pass through requests with the `user=me` request parameter. It is used just to show
+how to register custom filters with annotations. The implementation itself is not useful.
 
-New lines in log will appear confirming filter installation:
+Upon start-up, new logs will confirm successful filter installation:
 
 ```
 INFO  [2017-02-11 17:18:16,943] ru.vyarus.dropwizard.guice.module.installer.feature.web.WebFilterInstaller: filters =
@@ -285,7 +286,7 @@ INFO  [2017-02-11 17:18:16,943] ru.vyarus.dropwizard.guice.module.installer.feat
 
 Call `http://localhost:8080/sample/` and `http://localhost:8080/sample/?user=me` to make sure filter works.
 
-### Add guice module
+### Adding a Guice Module
 
 Guice module registration:
 
@@ -302,13 +303,13 @@ Multiple modules could be registered at once:
 ```
 
 !!! note
-    Registration above occur in dropwizard initialization phase, when neither `Configuration`
-    nor `Environment` objects are available, but if you need them in module then either
+    The above registration occurs in dropwizard initialization phase, when neither `Configuration`
+    nor `Environment` objects are available. If you need access to them in a module then either
     register module in [guicey bundle's](guide/bundles.md#guicey-bundles) run method or use [marker interfaces](guide/guice/module-autowiring.md)
         
 ## Manual mode
 
-If you don't want to use classpath scan, then you will have to manually specify all extensions.
+If you don't want to use classpath scanning for extension discovery, then you will have to manually specify all extensions.
 Example above would look in manual mode like this:
 
 ```java
@@ -322,17 +323,18 @@ bootstrap.addBundle(GuiceBundle.builder()
                 .build());
 ```
 
-The only difference is the absence of classpath scan (but you'll have to manually declare all extensions).
+The only difference is the absence of `.enableAutoConfig(...)` and the explicit declaration of desired all extensions.
 
 !!! tip
-    Explicit extensions declaration could be used together with classpath scan: for example,
-    classpath scan could not cover all packages with extensions (e.g. due to too much classes)
-    and not covered extensions may be specified manually.    
+    Explicit extension declaration could be used together with `enableAutoConfig` (classpath scan). For example,
+    a classpath scan may only scan for extensions in your application's package and subpackages, while extensions from outside 
+    those packages may be specified separately. This avoids large class path scans and improves the startup time of your 
+    application.
 
 !!! note
-    Duplicate extensions are filtered. If some extension is registered manually and also found with auto scan
-    then only one extension instance will be registered. 
-    Even if extension registered multiple times manually, only one extension will work. 
+    Only distinct extensions are registered. Duplicates are not registered. If some extension is registered manually and also found 
+    with auto config, then only one instance of that extension will be registered. If an extension is registered multiple times 
+    manually, the same rules apply and only one extension instance will be registered. 
 
 ## Configuration from bindings
 
@@ -349,20 +351,20 @@ public class SampleModule extends AbstractModule {
     protected void configure() {
          bind(SampleResource.class).in(Singleton.class);
          bind(SampleBootstrap.class);
-         bind(CustomHeaderFilter.clas);                        
+         bind(CustomHeaderFilter.class);                        
     }   
 }
 ```     
 
-Guicey will recognize all (3) bindings and register extensions. The difference with classpath scan 
+Guicey will recognize all three bindings and register extensions. The difference with classpath scanning
 or manual declaration is only that guicey will not declare default bindings for extensions 
 (by default, guicey creates untargetted bindings for all extensions: `bind(Extension.class)`).
 
 !!! tip
-    One extension may be found by classpath scan, declared manually and in binding,
+    One extension may be found by classpath scan and declared manually in binding,
     but it would still be considered as single registration (with existing binding).
 
-## Possible extensions
+## Recognized Extensions
 
 Guicey can recognize and install:
 
@@ -377,13 +379,12 @@ Guicey can recognize and install:
 
 It can even simulate simple [plugins](installers/plugin.md).
 
-Other extension types may appear with additional modules (e.g. [jdbi](extras/jdbi3.md) adds 
-support for jdbi mappers and repositories) or may be added by yourself. Any existing extension 
-integration may be replaced, if it doesn't suite your needs.
+Other extension types may be recognized with additional installed modules. For example, [jdbi](extras/jdbi3.md) adds 
+support for jdbi mappers and repositories. You may add others yourself. Any existing extension integration may be 
+replaced, if it doesn't suit your needs.
 
 !!! tip
-    If you'll feel confusing to understand what guicey use for it's configuration, 
-    just enable diagnostic logs:
+    If you are unsure or don't understand what guicey is using for its configuration, enable diagnostic logs:
     ```java
     GuiceBundle.builder()        
         .printDiagnosticInfo()
@@ -402,17 +403,17 @@ integration may be replaced, if it doesn't suite your needs.
         .printGuiceBindings()    
     ```
 
-## Bundles 
+## Guicey Bundles 
 
-Guicey intended to extend dropwizard abilities (not limit). But to get access for these extended 
-abilities you'll need to use [GuiceyBundle](guide/bundles.md) instead of dropwizard `ConfiguredBundle`.
+Guicey Bundles are intended to extend the functionality of Dropwizard Bundles, not limit them. To get access for these extended 
+abilities you'll need to use [GuiceyBundle](guide/bundles.md) instead of a dropwizard `ConfiguredBundle`.
 
-Bundles **lifecycle and methods are the same**, just guicey bundle provide more abilities.
+The Guicey Bundle **lifecycle and methods are the same** as Dropwizard Bundles. Guicey Bundles simply provide more functionality.
 
 
 !!! attention
-    This does not mean that dropwizard bundles can't be used! An opposite, guicey provides
-    direct shortcuts for them in it's bundles:
+    This does not mean that dropwizard bundles can't be used! An opposite, Guicey provides
+    direct shortcuts for them in its bundles:
     
     ```java
     public class MyBundle implements GuiceyBundle {
@@ -422,11 +423,10 @@ Bundles **lifecycle and methods are the same**, just guicey bundle provide more 
     }
     ```     
     
-    Additional features will be available for dropwizard bundles registered through guicey api and
+    Additional features will be available for Dropwizard Bundles registered through guicey api and
     they also will appear in reports.                          
 
 
-You can use dropwizard bundles as before if you don't need to register guice modules 
-or use other guicey features from them. Usually dropwizard bundles used when
-required integration already implemented as dropwizard bundle (3rd parties).
- 
+You can always use vanilla Dropwizard Bundles if you don't need to register guice modules 
+or use other guicey features. Usually Dropwizard Bundles used when the required integration has 
+already implemented as a 3rd party Dropwizard Bundle.

--- a/src/doc/docs/guide/bundles.md
+++ b/src/doc/docs/guide/bundles.md
@@ -96,15 +96,15 @@ Your bundles may be installed multiple times, and you must always think of what 
 For example:
 
 ```java
-.bundles(new MyBundle(), new MuBundle())
+.bundles(new MyBundle(), new MyBundle())
 ```
 
 Bundles are often intended to be used multiple times (for example, [spa bundle](../extras/spa.md)).
 
 But in some cases, only one bundle instance must be installed. For example, [eventbus bundle](../extras/eventbus.md)
-must be installed just once. The opposite may be true, a common bundle could be installed by multiple other bundles.
+must be installed just once. The opposite may be true: a common bundle could be installed by multiple other bundles.
 
-In order to manage these such cases guicey provides a [de-duplication mechanism](deduplication.md).
+In order to manage these cases guicey provides a [de-duplication mechanism](deduplication.md).
 
 To avoid redundant bundle instances, you can:
 

--- a/src/doc/docs/guide/bundles.md
+++ b/src/doc/docs/guide/bundles.md
@@ -1,18 +1,18 @@
 # Guicey bundles
 
-By analogy with dropwizard bundles, guicey has it's own `GuiceyBundle`. These bundles contains almost the same options as 
-main `GuiceBundle` [builder](configuration.md#main-bundle). The main purpose is the same as dropwizard bundles: incapsulate logic by grouping installers, 
-extensions and guice modules related to specific feature.
+Analogous to Dropwizard Bundles, Guicey has its own `GuiceyBundle`. These bundles contain many of the same options as the
+main `GuiceBundle` [builder](configuration.md#main-bundle). The purpose of Guicey Bundles is the same as Dropwizard Bundles: 
+encapsulate logic by grouping installers, extensions and guice modules related to specific features and libraries.
 
 !!! note
     Guicey bundles are assumed to be used **instead** of dropwizard bundles in guicey-powered application.
     
     It does not mean that drowpizard bundles can't be used - of course they can! There are many
-    [existing dropwizard bundles](https://modules.dropwizard.io/thirdparty/) and it would be insance to get rid of them.
+    [existing dropwizard bundles](https://modules.dropwizard.io/thirdparty/) and it would be insane to get rid of them.
     
-    It is just not possible to register guice modules and use many guicey features from dropwizard bundles.       
+    It is not possible to register guice modules and use many guicey features from dropwizard bundles.       
 
-Guicey and dropwizard bundles share **the same lifecycle**:
+Guicey and Dropwizard Bundles share **the same lifecycle**:
 
 ```java     
 public interface ConfiguredBundle<T> {
@@ -26,14 +26,14 @@ public interface GuiceyBundle {
 }
 ```
 
-Guicey bundles is an extension to dropwizard bundles (without restrictions), 
+Guicey Bundles are an extension to dropwizard bundles (without restrictions), 
 so it is extremely simple to switch from dropwizard bundles.
 
 !!! tip
-    With guicey bundles it is possible to implement [plug-and-play](#service-loader-lookup) bundles:
-    to automatically install bundle when it's jar appear on classpath. 
+    With Guicey Bundles, it is possible to implement [plug-and-play](#service-loader-lookup) bundles
+    to automatically install a bundle when its jar appears on the classpath. 
 
-Example guicey bundle:
+Example Guicey bundle:
 
 ```java
 public class MyFeatureBundle implements GuiceyBundle {
@@ -68,7 +68,7 @@ bootstrap.addBundle(GuiceBundle.builder()
 );
 ```
 
-Example bundles could by found in guicey itself:
+Example bundles can be found in Guicey itself:
 
 * `CoreInstallersBundle` - all default installers
 * `WebInstallersBundle` - servlet and filter annotations support
@@ -81,18 +81,17 @@ Even more examples are in [extensions modules](../extras/bom.md)
 See all [bundle configuration options](configuration.md#guicey-bundle)
 
 !!! note
-    Almost all configurations appear under initialization phase only. This was done in order
-    to follow dropwizard conventions (all configuration under init and all initialization under run).
+    Most configurations only appear during the initialization phase. This was done in order
+    to follow dropwizard conventions (all configuration during init and all initialization on run).
 
-The only exception is guice modules: it is allowed to register modules in both phases. 
-Modules are often require direct configuration values and without this exception it would
-be too often required to create wrapper [guicey-aware](guice/module-autowiring.md) modules
-for proper registration. Besides, in dropwizard itself HK2 modules could only be registered in run phase.   
+The only exception to this rule is the registration of guice modules. Bundles are allowed to register modules in both phases. 
+Guice modules often require direct configuration values. Without this exception, Guicey Bundle authors would be required to create 
+wrappers around [guicey-aware](guice/module-autowiring.md) modules for proper guice registrations. Dropwizard itself shares a 
+similar exception in that HK2 modules may only be registered during the run phase.   
 
-## De-duplication
+## Bundle De-duplication
 
-Your bundle may be installed multiple times and you must always think what is **expected behaviour**
-in this case.
+Your bundles may be installed multiple times, and you must always think of what should be **expected behaviour** in these cases.
 
 For example:
 
@@ -103,11 +102,11 @@ For example:
 Bundles are often intended to be used multiple times (for example, [spa bundle](../extras/spa.md)).
 
 But in some cases, only one bundle instance must be installed. For example, [eventbus bundle](../extras/eventbus.md)
-must be installed just once. Or it may be some common bundle, installed by multiple other bundles.
+must be installed just once. The opposite may be true, a common bundle could be installed by multiple other bundles.
 
-In order to solve such cases guicey provides [de-duplication mechanism](deduplication.md).
+In order to manage these such cases guicey provides a [de-duplication mechanism](deduplication.md).
 
-So when you need to avoid redundant bundle instances, you can:
+To avoid redundant bundle instances, you can:
 
 * extend `UniqueGuiceyBundle` to allow only one bundle instance
 * implement `equals` method (where you can implement any deduplication rules (e.g. based on bundles constructor arguments))
@@ -120,9 +119,9 @@ So when you need to avoid redundant bundle instances, you can:
     always be registered first, and bundle obtained with lookup mechansm would be considered 
     as duplicate and not used (for example, [eventbus bundle](../extras/eventbus.md) use this)
 
-## Bundle lookup
+## Bundle Lookup
 
-Bundle lookup mechanism used to lookup guicey bundles in various sources. It may be used to activate specific bundles
+The bundle lookup mechanism is used to lookup guicey bundles in various sources. It may be used to activate specific bundles
 in tests (e.g. [HK2 scope control bundle](hk2.md#hk2-scope-debug)) or to install 3rd party extensions from classpath.
 
 Bundle lookup is equivalent to registering bundle directly using builder `bundles` method.
@@ -172,11 +171,11 @@ PropertyBundleLookup.enableBundles(HK2DebugBundle.class)
 Using default java [ServiceLoader](https://docs.oracle.com/javase/7/docs/api/java/util/ServiceLoader.html) 
 mechanism, loads all `GuiceyBundle` services.
 
-This is useful for automatically install 3rd party extensions (additional installers, extensions, guice modules).
+This is useful for automatically installing 3rd party extensions (additional installers, extensions, guice modules).
 
 !!! note
-    This could be used to install bundle with default configuration: with proper [de-duplication](deduplication.md)
-    if user register custom bundle version, it will be used and bundle from lookup will be ignored.
+    This could be used to install bundles with default configuration and proper [de-duplication](deduplication.md).
+    If a user register custom bundle version, it will be used and bundle from lookup will be ignored.
      
     For example, [eventbus](../extras/eventbus.md) bundle works like this
 
@@ -186,14 +185,15 @@ This is useful for automatically install 3rd party extensions (additional instal
 META-INF/services/ru.vyarus.dropwizard.guice.module.installer.bundle.GuiceyBundle
 ```
 
-File contain one or more (per line) GuiceyBundle implementations. E.g.
+The file must contain one GuiceyBundle implementation per line. 
 
+For example:
 ```
 com.foo.Bundle1
 com.foo.Bundle2
 ```
 
-Then Bundle1, Bundle2 would be loaded automatically on startup (would appear in logs).
+Then Bundle1, Bundle2 would be loaded automatically on startup and appear in logs.
 
 ### Customizing lookup mechanism
 
@@ -228,7 +228,7 @@ bootstrap.addBundle(GuiceBundle.builder()
         .build()
 ```
 
-To override list of default lookups:
+To override the list of default lookups:
 
 ```java
 bootstrap.addBundle(GuiceBundle.builder()
@@ -236,11 +236,11 @@ bootstrap.addBundle(GuiceBundle.builder()
         .build()
 ```
 
-Here two lookup mechanisms registered (property lookup is not registered and will not be implicitly added).
+Here, only two lookup mechanisms registered (property lookup is not registered and will **not** be implicitly added).
 
 ## Dropwizard bundles
 
-Dropwizard bundles can be used as before: be registered directly in `Bootstrap`.
+Dropwizard bundles can be used as before, registered directly in `Bootstrap`.
 
 Guicey provides direct api for dropwizard bundles registration:
 
@@ -261,7 +261,7 @@ public class MyBundle implements GuiceyBundle {
 ```    
 
 !!! note
-    The most common case is: extending some existing 3rd party integration (dropwizard bundle)
+    The most common case is extending some existing 3rd party integration (Dropwizard Bundle)
     with guice bindings (or adding guicey installers for simplified usage). 
     
     ```java
@@ -284,22 +284,22 @@ When you register dropwizard bundles through guicey api:
 * Bundle itself or any transitive bundle could be [disabled](disables.md#disable-dropwizard-bundles)
 * [De-duplication mechanism](deduplication.md#dropwizard-bundles) will work for bundle and it's transitive bundles
 
-So, for example, if you have "common bundle" problem (when 2 bundles register some common bundle and so you can use these
-bundles together) it could be solved just by registering bundle throug guicey api (and [proper configuration](deduplication.md#unique-items))
+So, if you have a "common bundle" problem (when 2 bundles register some common bundle and so you can use these
+bundles together) it could be solved just by registering bundle through the guicey api with 
+[proper configuration](deduplication.md#unique-items).
 
 ### Transitive bundles tracking
 
-Transitive dropwizard bundles are tracked with a `Bootstrap` object proxy 
-(so guicey could intercept `addBundle` call).
+Transitive dropwizard bundles are tracked with a `Bootstrap` object proxy so guicey could intercept the `addBundle` call.
 
-If you have problems with it, you can switch off transitive bundles tracking:
+If you have problems with the proxy, you can switch off transitive bundles tracking:
 
 ```java
 .option(GuiceyOptions.TrackDropwizardBundles, false)
 ```
 
-If you don't want to switch off tracking, but still have problems registering some bundle,
-you can always register it directly in bootstrap object:
+If you don't want to switch off tracking, but still have problems registering some bundle, you can always register it directly in 
+bootstrap object:
 
 ```java
 public class MyBundle implements GuiceyBundle {

--- a/src/doc/docs/index.md
+++ b/src/doc/docs/index.md
@@ -31,26 +31,27 @@
   
 <sup>If guicey makes your life easier, you can [support its development](https://www.patreon.com/guicey).</sup>
 
-## How to use docs
+## Documentation Summary
 
 ### Introduction
 
-* [**Getting started**](getting-started.md) guide describes installation and shows core usage examples
-* [**Concepts overview**](concepts.md) guide introduce core guicey concepts and explains differences with pure dropwizard usage
-* [**Gucie**](guice.md) the essence of guice integration
+* [**Getting started**](getting-started.md) guide describes installation and provides core usage examples
+* [**Concepts overview**](concepts.md) guide introduces core guicey concepts and demonstrates differences from pure dropwizard usage
+* [**Guice**](guice.md) the essence of guice integration
 * [**Testing**](tests.md) describes integration testing techniques
 * [**Decomposition**](tests.md) guide on writing re-usable modules
 
 ### Reference
-* [**User guide**](guide/configuration.md) contain detailed features descriptions. Good to read, but if no time, read as you need it.
+* [**User guide**](guide/configuration.md) contains detailed feature descriptions. It is good to read, but it also functions 
+  well as a reference if you're short on time.
 * [**Installers**](installers/resource.md) describes all guicey installers. Use it as a *extensions hand book*.
-* [**Modules**](guide/modules.md) extension modules 
-* [**Examples**](examples/authentication.md) important usage examples. Look also [examples repository](https://github.com/xvik/dropwizard-guicey-examples) for additional examples. 
+* [**Modules**](guide/modules.md) external extension modules overview.
+* [**Examples**](examples/authentication.md) important usage examples. 
 
 ## Sources structure
 
-* [Guicey repository]((https://github.com/xvik/dropwizard-guicey)): guicey itself and (this) docs
+* [Guicey repository]((https://github.com/xvik/dropwizard-guicey)): guicey itself and (these) docs
 * [Modules repository](https://github.com/xvik/dropwizard-guicey-ext): extension [modules](guide/modules.md) (integrations) 
 are maintained in the separate repository
-* [Examples repository](https://github.com/xvik/dropwizard-guicey-examples) holds usage examples of main features usage, 
-dropwizard bundles integrations and extension modules samples.  
+* [Examples repository](https://github.com/xvik/dropwizard-guicey-examples): holds code samples for main features dropwizard 
+bundles and extension modules.


### PR DESCRIPTION
Here is my first foray into tightening up the documentation. This PR is only over three files, If it is welcomed I will do more.

I attempted to keep the content and meaning the same, only making adjustments to grammar, spelling, and phrasing (idiomatic English is a nightmare, I can't imagine trying to learn the nuances as a second language). 

Now that I've started going through it in detail, I have a list of changes I'd like to make to standardize documentation, but I'll open an issue with those suggestions before I implement them. 