### PR TITLE
Replace `jakarta.` with `javax.` for Dropwizard 3.x

### DIFF
--- a/dropwizard-guicey/src/main/java/ru/vyarus/dropwizard/guice/module/yaml/ConfigTreeBuilder.java
+++ b/dropwizard-guicey/src/main/java/ru/vyarus/dropwizard/guice/module/yaml/ConfigTreeBuilder.java
@@ -14,7 +14,7 @@ import io.dropwizard.core.Configuration;
 import io.dropwizard.core.setup.Bootstrap;
 import io.dropwizard.util.DataSize;
 import io.dropwizard.util.Duration;
-import jakarta.inject.Qualifier;
+import javax.inject.Qualifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ru.vyarus.java.generics.resolver.GenericsResolver;
@@ -502,7 +502,7 @@ public final class ConfigTreeBuilder {
             for (Annotation marker : ann.annotationType().getAnnotations()) {
                 final Class<? extends Annotation> type = marker.annotationType();
                 if (type.equals(Qualifier.class)
-                        || type.equals(javax.inject.Qualifier.class)
+                        || type.equals(Qualifier.class)
                         || type.equals(BindingAnnotation.class)) {
                     return ann;
                 }

--- a/dropwizard-guicey/src/test/groovy/ru/vyarus/dropwizard/guice/test/jupiter/NestedTreeTest.java
+++ b/dropwizard-guicey/src/test/groovy/ru/vyarus/dropwizard/guice/test/jupiter/NestedTreeTest.java
@@ -2,7 +2,7 @@ package ru.vyarus.dropwizard.guice.test.jupiter;
 
 import io.dropwizard.core.setup.Environment;
 import io.dropwizard.testing.DropwizardTestSupport;
-import jakarta.inject.Inject;
+import javax.inject.Inject;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
Version `6.2.0` introduced a couple of `jakarta` imports that break applications at runtime.